### PR TITLE
Resolves #7

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: geojson
-version: 0.1.2
+version: 0.1.3
 
 authors:
   - Benjamin Wade

--- a/src/geojson.cr
+++ b/src/geojson.cr
@@ -1,5 +1,5 @@
 require "./geojson/**"
 
 module GeoJSON
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/src/geojson/base.cr
+++ b/src/geojson/base.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module GeoJSON
   # A `GeoJSON::Base` specifies the properties shared by all GeoJSON classes.
   private abstract class Base

--- a/src/geojson/coordinates/linear_ring.cr
+++ b/src/geojson/coordinates/linear_ring.cr
@@ -1,6 +1,5 @@
-require "./malformed_coordinate_exception"
-require "./coordinates"
 require "./line_string_coordinates"
+require "./malformed_coordinate_exception"
 
 module GeoJSON::Coordinates
   # A `LinearRing` is a closed set of `LineStringCoordinates`. To satisfy this

--- a/src/geojson/coordinates/poly_rings.cr
+++ b/src/geojson/coordinates/poly_rings.cr
@@ -1,4 +1,3 @@
-require "./malformed_coordinate_exception"
 require "./coordinates"
 require "./linear_ring"
 

--- a/src/geojson/coordinates/position.cr
+++ b/src/geojson/coordinates/position.cr
@@ -1,5 +1,6 @@
-require "./malformed_coordinate_exception"
 require "./coordinates"
+require "./coordinate_tree"
+require "./malformed_coordinate_exception"
 
 module GeoJSON::Coordinates
   # A `Position` represents a position on earth with a longitude, latitude, and

--- a/src/geojson/feature.cr
+++ b/src/geojson/feature.cr
@@ -1,4 +1,13 @@
+require "json"
+
+require "./base"
+require "./geometry/geometry"
+require "./geometry/geometry_collection"
+require "./geometry/pseudo_geometry_converter"
+
 module GeoJSON
+  alias PseudoGeometry = Geometry | GeometryCollection
+
   # A `Feature` represents a [GeoJSON Feature object](https://tools.ietf.org/html/rfc7946#section-3.2)
   # with a geometry and properties.
   class Feature < Base
@@ -7,7 +16,7 @@ module GeoJSON
     # Gets this Feature's GeoJSON type ("Feature")
     getter type : String = "Feature"
 
-    @[JSON::Field(emit_null: true)]
+    @[JSON::Field(emit_null: true, converter: GeoJSON::PseudoGeometryConverter)]
     # Gets this Feature's geometry.
     getter geometry : PseudoGeometry?
 

--- a/src/geojson/feature_collection.cr
+++ b/src/geojson/feature_collection.cr
@@ -1,3 +1,8 @@
+require "json"
+
+require "./base"
+require "./feature"
+
 module GeoJSON
   # A `FeatureCollection` represents a [GeoJSON FeatureCollection object](https://tools.ietf.org/html/rfc7946#section-3.3)
   # and contains one or more `Feature`s.

--- a/src/geojson/geometry/geometry.cr
+++ b/src/geojson/geometry/geometry.cr
@@ -58,7 +58,7 @@ module GeoJSON
     protected def self.create_geometry(of_type geometry_type, with coordinates)
       {% begin %}
         case geometry_type
-        {% for klass in @type.subclasses %}
+        {% for klass in @type.subclasses.map(&.id.split("::").last) %}
           when "{{klass.id}}"
             {{klass.id}}.new coordinates
         {% end %}

--- a/src/geojson/geometry/geometry.cr
+++ b/src/geojson/geometry/geometry.cr
@@ -1,8 +1,11 @@
 require "json"
 
+require "../base"
 require "../coordinates/coordinate_tree"
 
 module GeoJSON
+  include Coordinates
+
   # A `Geometry` represents a figure in geographic space.
   abstract class Geometry < Base
     # Returns this Geometry's coordinates.

--- a/src/geojson/geometry/geometry.cr
+++ b/src/geojson/geometry/geometry.cr
@@ -1,9 +1,10 @@
 require "json"
-require "./pseudo_geometry"
+
+require "../coordinates/coordinate_tree"
 
 module GeoJSON
   # A `Geometry` represents a figure in geographic space.
-  abstract class Geometry < PseudoGeometry
+  abstract class Geometry < Base
     # Returns this Geometry's coordinates.
     abstract def coordinates
 
@@ -28,7 +29,22 @@ module GeoJSON
     # Parses the geometry type and coordinates (returned as a tuple, in that
     # order) from the given *parser*.
     private def self.parse_geometry(using parser : JSON::PullParser)
-      element_type, contents = parse_pseudo_geometry using: parser
+      parser.read_begin_object
+      while parser.kind != JSON::PullParser::Kind::EndObject
+        case parser.read_string
+        when "type"
+          begin
+            element_type = parser.read_string
+          rescue JSON::ParseException
+            raise "Type field is not a string!"
+          end
+        when "coordinates"
+          contents = CoordinateTree.new parser
+        else
+          parser.read_next # we currently ignore extra elements
+        end
+      end
+      parser.read_end_object
 
       if element_type == "GeometryCollection"
         raise "GeometryCollection is not a Geometry!"
@@ -40,22 +56,16 @@ module GeoJSON
     # Creates a geometry of the given *geometry_type* with the given
     # *coordinates*.
     protected def self.create_geometry(of_type geometry_type, with coordinates)
-      case geometry_type
-      when "Point"
-        Point.new coordinates
-      when "MultiPoint"
-        MultiPoint.new coordinates
-      when "LineString"
-        LineString.new coordinates
-      when "MultiLineString"
-        MultiLineString.new coordinates
-      when "Polygon"
-        Polygon.new coordinates
-      when "MultiPolygon"
-        MultiPolygon.new coordinates
-      else
-        raise %(Invalid geometry type "#{geometry_type}"!)
-      end
+      {% begin %}
+        case geometry_type
+        {% for klass in @type.subclasses %}
+          when "{{klass.id}}"
+            {{klass.id}}.new coordinates
+        {% end %}
+        else
+          raise %(Invalid geometry type "#{geometry_type}"!)
+        end
+      {% end %}
     end
 
     # Creates a `Geometry` from the given GeoJSON string.

--- a/src/geojson/geometry/geometry_collection.cr
+++ b/src/geojson/geometry/geometry_collection.cr
@@ -1,12 +1,11 @@
 require "./geometry"
-require "./pseudo_geometry"
 
 module GeoJSON
   # A `GeometryCollection` represents a collection of several geometries
   # (`Geometry` objects).
   #
   # This class corresponds to the [GeoJSON GeometryCollection](https://tools.ietf.org/html/rfc7946#section-3.1.8).
-  class GeometryCollection < PseudoGeometry
+  class GeometryCollection < Base
     include JSON::Serializable
 
     # Gets this GeometryCollection's GeoJSON type ("GeometryCollection")

--- a/src/geojson/geometry/geometry_collection.cr
+++ b/src/geojson/geometry/geometry_collection.cr
@@ -1,3 +1,4 @@
+require "../base"
 require "./geometry"
 
 module GeoJSON

--- a/src/geojson/geometry/line_string.cr
+++ b/src/geojson/geometry/line_string.cr
@@ -1,6 +1,5 @@
 require "./geometry"
 require "./single_geometry"
-require "../coordinates/position"
 require "../coordinates/line_string_coordinates"
 
 module GeoJSON

--- a/src/geojson/geometry/multi_geometry.cr
+++ b/src/geojson/geometry/multi_geometry.cr
@@ -1,3 +1,5 @@
+require "../coordinates/coordinate_tree"
+
 module GeoJSON
   # A `MultiGeometry` is a `Geometry` corresponding to a "normal geometry" type
   # *T* and which can contain multiple coordinates of type *E*.

--- a/src/geojson/geometry/multi_line_string.cr
+++ b/src/geojson/geometry/multi_line_string.cr
@@ -1,4 +1,7 @@
+require "./geometry"
+require "./multi_geometry"
 require "./line_string"
+require "../coordinates/line_string_coordinates"
 
 module GeoJSON
   # A `MultiLineString` is a `Geometry` representing several `LineString`s.

--- a/src/geojson/geometry/multi_point.cr
+++ b/src/geojson/geometry/multi_point.cr
@@ -1,4 +1,7 @@
+require "./geometry"
+require "./multi_geometry"
 require "./point"
+require "../coordinates/position"
 
 module GeoJSON
   # A `MultiPoint` is a `Geometry` representing several `Point`s.

--- a/src/geojson/geometry/multi_polygon.cr
+++ b/src/geojson/geometry/multi_polygon.cr
@@ -1,4 +1,7 @@
+require "./geometry"
+require "./multi_geometry"
 require "./polygon"
+require "../coordinates/poly_rings"
 
 module GeoJSON
   # A `MultiPolygon` is a `Geometry` representing several `Polygon`s.

--- a/src/geojson/geometry/polygon.cr
+++ b/src/geojson/geometry/polygon.cr
@@ -1,7 +1,7 @@
 require "./geometry"
 require "./single_geometry"
-require "../coordinates/linear_ring"
 require "../coordinates/poly_rings"
+require "../coordinates/linear_ring"
 
 module GeoJSON
   # A `Polygon` is a `Geometry` representing a closed geometric figure in

--- a/src/geojson/geometry/pseudo_geometry_converter.cr
+++ b/src/geojson/geometry/pseudo_geometry_converter.cr
@@ -5,8 +5,6 @@ require "./geometry_collection"
 require "../coordinates/coordinate_tree"
 
 module GeoJSON
-  include Coordinates
-
   # A `PseudoGeometryConverter` handles deserialization and serialization of
   # geometry elements in GeoJSON features.
   struct PseudoGeometryConverter

--- a/src/geojson/geometry/pseudo_geometry_converter.cr
+++ b/src/geojson/geometry/pseudo_geometry_converter.cr
@@ -1,19 +1,18 @@
 require "json"
 
-require "../base"
+require "./geometry"
+require "./geometry_collection"
+require "../coordinates/coordinate_tree"
 
 module GeoJSON
-  # A `PseudoGeometry` is a geometry element in a GeoJSON feature.
-  #
-  # This class is really just a union of `Geometry` and `GeometryCollection`
-  # with built-in JSON parsing logic.
-  abstract class PseudoGeometry < Base
-    # Creates a new `PseudoGeometry` from the given *parser*.
-    #
-    # This static class method automatically chooses the correct
-    # PseudoGeometry class (`Geometry` or `GeometryCollection`) to create.
-    def self.new(parser : JSON::PullParser)
-      element_type, contents = parse_pseudo_geometry using: parser
+  include Coordinates
+
+  # A `PseudoGeometryConverter` handles deserialization and serialization of
+  # geometry elements in GeoJSON features.
+  struct PseudoGeometryConverter
+    # Creates a `Geometry` or `GeometryCollection` from the given GeoJSON string.
+    def self.from_json(parser : JSON::PullParser)
+      element_type, contents = self.parse_pseudo_geometry using: parser
 
       if element_type.nil?
         raise "Type field missing!"
@@ -64,9 +63,10 @@ module GeoJSON
       end
     end
 
-    # Creates a `Geometry` or `GeometryCollection` from the given GeoJSON string.
-    def PseudoGeometry.from_json(geometry_json)
-      PseudoGeometry.new(JSON::PullParser.new geometry_json)
+    # Serializes a `Geometry` or `GeometryCollection` by passing the *builder*
+    # to its `#to_json` method.
+    def self.to_json(value, builder : JSON::Builder)
+      value.to_json builder
     end
   end
 end

--- a/src/geojson/geometry/single_geometry.cr
+++ b/src/geojson/geometry/single_geometry.cr
@@ -1,3 +1,5 @@
+require "../coordinates/coordinate_tree"
+
 module GeoJSON
   # A `SingleGeometry` is a `Geometry` with a single `Coordinates` member of
   # type *T*.


### PR DESCRIPTION
This PR is meant to fix the `require` and `include` hierarchies within this project. In the process, I cleaned up the type hierarchy for `Geometry` and `GeometryCollection`: instead of a `PseudoGeometry` superclass, they are now handled in `Feature` by a `PseudoGeometryConverter` which has the same deserialization logic previously in `PseudoGeometry`. This change (as well as macro usage in `Geometry`) allows us to avoid circular dependencies that are causing problems.

Points that deserve some consideration:
* I wasn't sure how to integrate testing of `require` and `include` behavior into the specs, so I didn't.
* I only bumped the version by a patch version; technically, replacing `PseudoGeometry` is a breaking change, but 1) I don't think anyone actually uses this shard yet, and 2) it doesn't change the "intended-to-use" API at all.